### PR TITLE
Fix 58777

### DIFF
--- a/EPPlus/EPPlus.MultiTarget.csproj
+++ b/EPPlus/EPPlus.MultiTarget.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;net40</TargetFrameworks>
-    <AssemblyVersion>4.5.3.4</AssemblyVersion>
-    <FileVersion>4.5.3.4</FileVersion>
-    <Version>4.5.3.4</Version>
+    <AssemblyVersion>4.5.3.5</AssemblyVersion>
+    <FileVersion>4.5.3.5</FileVersion>
+    <Version>4.5.3.5</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/JanKallman/EPPlus</PackageProjectUrl>

--- a/EPPlus/ExcelAddress.cs
+++ b/EPPlus/ExcelAddress.cs
@@ -730,7 +730,26 @@ namespace OfficeOpenXml
             }
             else if (row <= _fromRow)
             {
-                return new ExcelAddressBase((setFixed && _fromRowFixed ? _fromRow : _fromRow + rows), _fromCol, (setFixed && _toRowFixed ? _toRow : _toRow + rows), _toCol, _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed);
+	            var newFromRow = _fromRow + rows;
+	            if (setFixed && _fromRowFixed)
+	            {
+		            newFromRow = _fromRow;
+	            }
+                else if (_fromRowFixed && _toRowFixed 
+						 && _fromRow == 1 && _toRow == ExcelPackage.MaxRows)
+	            {
+		            newFromRow = _fromRow;
+	            }
+
+	            var newToRow = Math.Min((setFixed && _toRowFixed ? _toRow : _toRow + rows), ExcelPackage.MaxRows);
+	            return new ExcelAddressBase(newFromRow, 
+	                _fromCol, 
+	                newToRow, 
+	                _toCol, 
+	                _fromRowFixed, 
+	                _fromColFixed, 
+	                _toRowFixed, 
+	                _toColFixed);
             }
             else
             {

--- a/EPPlus/ExcelAddress.cs
+++ b/EPPlus/ExcelAddress.cs
@@ -753,7 +753,16 @@ namespace OfficeOpenXml
             }
             else
             {
-                return new ExcelAddressBase(_fromRow, _fromCol, (setFixed && _toRowFixed ? _toRow : _toRow + rows), _toCol, _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed);
+                return new ExcelAddressBase(_fromRow,
+	                _fromCol,
+	                (setFixed && _toRowFixed
+		                ? _toRow
+		                : Math.Min(_toRow + rows, ExcelPackage.MaxRows)),
+	                _toCol,
+	                _fromRowFixed,
+	                _fromColFixed,
+	                _toRowFixed,
+	                _toColFixed);
             }
         }
         internal ExcelAddressBase DeleteRow(int row, int rows, bool setFixed = false)

--- a/EPPlus/ExcelCellBase.cs
+++ b/EPPlus/ExcelCellBase.cs
@@ -609,6 +609,9 @@ namespace OfficeOpenXml
               }
             }
           }
+
+          fixedRow |= row == 0;
+          fixedCol |= col == 0;
           return row != 0 || col != 0;
         }
 

--- a/EPPlusTest/AddressTests.cs
+++ b/EPPlusTest/AddressTests.cs
@@ -319,6 +319,21 @@ namespace EPPlusTest
             Assert.IsFalse(ExcelCellBase.IsValidAddress("$A$12:$XY$13,$A12:XY$14$"));
         }
 
+        [TestMethod]
+        public void InsertRows_ExtendColumnTest()
+        {
+	        using (var package = new ExcelPackage())
+	        {
+                const string formula = "'NEW'!$A:$A";
+                var workbook = package.Workbook;
+		        var sheet1 = package.Workbook.Worksheets.Add("NEW");
+		        var sheet2 = package.Workbook.Worksheets.Add("NEW2");
+		        sheet2.Cells[1, 1].Formula = formula;
 
+		        sheet1.InsertRow(1, 10);
+
+		        Assert.AreEqual(formula, sheet2.Cells[1, 1].Formula);
+	        }
+        }
     }
 }

--- a/EPPlusTest/AddressTests.cs
+++ b/EPPlusTest/AddressTests.cs
@@ -319,8 +319,13 @@ namespace EPPlusTest
             Assert.IsFalse(ExcelCellBase.IsValidAddress("$A$12:$XY$13,$A12:XY$14$"));
         }
 
-        [TestMethod]
-        public void InsertRows_ExtendColumnTest()
+        [DataTestMethod]
+        [DataRow(1 ,5)]
+        [DataRow(1, ExcelPackage.MaxRows)]
+        [DataRow(2, 1)]
+        [DataRow(ExcelPackage.MaxRows, 5)]
+        [DataRow(ExcelPackage.MaxRows, ExcelPackage.MaxRows)]
+        public void InsertRow_ExtendColumnTest(int fromRowIndex, int insertedRows)
         {
 	        using (var package = new ExcelPackage())
 	        {
@@ -330,7 +335,7 @@ namespace EPPlusTest
 		        var sheet2 = package.Workbook.Worksheets.Add("NEW2");
 		        sheet2.Cells[1, 1].Formula = formula;
 
-		        sheet1.InsertRow(1, 10);
+		        sheet1.InsertRow(fromRowIndex, insertedRows);
 
 		        Assert.AreEqual(formula, sheet2.Cells[1, 1].Formula);
 	        }

--- a/EPPlusTest/CalculationTests.cs
+++ b/EPPlusTest/CalculationTests.cs
@@ -269,7 +269,7 @@ namespace EPPlusTest
             var pck = new ExcelPackage();
             var ws = pck.Workbook.Worksheets.Add("CalcTest");
             var currentDate = DateTime.UtcNow.Date;
-            ws.SetValue("A1", currentDate.ToString("MM/dd/yyyy"));
+            ws.SetValue("A1", currentDate.ToShortDateString());
             ws.SetValue("A2", currentDate.Date);
             ws.SetValue("A3", "31.1");
             ws.SetValue("A4", 31.1);

--- a/EPPlusTest/FormulaParsing/Excel/OperatorsTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/OperatorsTests.cs
@@ -184,15 +184,14 @@ namespace EPPlusTest.Excel
 		[TestMethod]
 		public void OperatorsActingOnDateStrings()
 		{
-            const string dateFormat = "M-dd-yyyy";
             DateTime date1 = new DateTime(2015, 2, 20);
             DateTime date2 = new DateTime(2015, 12, 1);
             var numericDate1 = date1.ToOADate();
             var numericDate2 = date2.ToOADate();
-            CompileResult result1 = new CompileResult(date1.ToString(dateFormat), DataType.String); // 2/20/2015
-            CompileResult result2 = new CompileResult(date2.ToString(dateFormat), DataType.String); // 12/1/2015
+            CompileResult result1 = new CompileResult(date1.ToShortDateString(), DataType.String); // 2/20/2015
+            CompileResult result2 = new CompileResult(date2.ToShortDateString(), DataType.String); // 12/1/2015
             var operatorResult = Operator.Concat.Apply(result1, result2);
-            Assert.AreEqual($"{date1.ToString(dateFormat)}{date2.ToString(dateFormat)}", operatorResult.Result);
+            Assert.AreEqual($"{date1.ToShortDateString()}{date2.ToShortDateString()}", operatorResult.Result);
             operatorResult = Operator.Divide.Apply(result1, result2);
             Assert.AreEqual(numericDate1 / numericDate2, operatorResult.Result);
             operatorResult = Operator.Exp.Apply(result1, result2);

--- a/EPPlusTest/Issues.cs
+++ b/EPPlusTest/Issues.cs
@@ -2392,11 +2392,11 @@ namespace EPPlusTest
         {
             using (var package = new ExcelPackage())
             {
-                var ws = package.Workbook.Worksheets.Add("TextBug");
-                ws.Cells["A1"].Value = new DateTime(2019, 3, 7);
-                ws.Cells["A1"].Style.Numberformat.Format = "mm-dd-yy";
+	            var ws = package.Workbook.Worksheets.Add("TextBug");
+	            ws.Cells["A1"].Value = new DateTime(2019, 3, 7);
+	            ws.Cells["A1"].Style.Numberformat.Format = "mm-dd-yy";
 
-                Assert.AreEqual("2019-03-07", ws.Cells["A1"].Text);
+	            Assert.AreEqual("2019-03-07", ws.Cells["A1"].Text);
             }
         }
         [TestMethod]

--- a/EPPlusTest/TestBase.cs
+++ b/EPPlusTest/TestBase.cs
@@ -11,7 +11,7 @@ namespace EPPlusTest
     {
         protected ExcelPackage _pck;
         protected string _clipartPath="";
-        protected string _worksheetPath= @"c:\epplusTest\Testoutput\";
+        protected string _worksheetPath;
         protected string _testInputPath = @"c:\epplusTest\workbooks\";
         public TestContext TestContext { get; set; }
         
@@ -49,14 +49,14 @@ namespace EPPlusTest
                     }
                 }
             }
-            
-            //_worksheetPath = Path.Combine(Path.GetTempPath(), @"EPPlus worksheets");
-            //if (!Directory.Exists(_worksheetPath))
-            //{
-            //    Directory.CreateDirectory(_worksheetPath);
-            //}
-            var di=new DirectoryInfo(_worksheetPath);            
-            _worksheetPath = di.FullName + "\\";
+
+			_worksheetPath = Path.Combine(Path.GetTempPath(), @"EPPlus worksheets");
+			if (!Directory.Exists(_worksheetPath))
+			{
+				Directory.CreateDirectory(_worksheetPath);
+			}
+			//var di=new DirectoryInfo(_worksheetPath);            
+			//_worksheetPath = di.FullName + "\\";
 
             _pck = new ExcelPackage();
         }


### PR DESCRIPTION
Fix: when inserting rows, the range in "A:A" format expand not correctly
Add unit test InsertRows_ExtendColumnTest
